### PR TITLE
Mysql5.6 repo

### DIFF
--- a/base/recipes/mysql.rb
+++ b/base/recipes/mysql.rb
@@ -8,6 +8,14 @@ execute "mysql-default-password-again" do
   user "root"
 end
 
+# Add the universe repository to help with dependency resolution
+apt_repository 'trusty-univers' do
+  uri 'http://archive.ubuntu.com/ubuntu'
+  components ['universe']
+  distribution 'trusty'
+  action :add
+end
+
 # Install mysql server
 execute "mysql-install" do
   command "(export DEBIAN_FRONTEND=\"noninteractive\"; sudo -E apt-get install -y -q mysql-server)"

--- a/base/recipes/mysql.rb
+++ b/base/recipes/mysql.rb
@@ -9,7 +9,7 @@ execute "mysql-default-password-again" do
 end
 
 # Add the universe repository to help with dependency resolution
-apt_repository 'trusty-univers' do
+apt_repository 'trusty-universe' do
   uri 'http://archive.ubuntu.com/ubuntu'
   components ['universe']
   distribution 'trusty'
@@ -18,7 +18,7 @@ end
 
 # Install mysql server
 execute "mysql-install" do
-  command "(export DEBIAN_FRONTEND=\"noninteractive\"; sudo -E apt-get install -y -q mysql-server)"
+  command "(export DEBIAN_FRONTEND=\"noninteractive\"; sudo -E apt-get install -y -q mysql-server-5.6 mysql-client-5.6 mysql-server-core-5.6)"
   user "root"
 end
 

--- a/base/recipes/mysql.rb
+++ b/base/recipes/mysql.rb
@@ -1,10 +1,10 @@
 # Set mysql server default password
 execute "mysql-default-password" do
-  command "echo \"mysql-server-5.7 mysql-server/mysql_password password #{node["mysql"]["root_password"]}\" | debconf-set-selections"
+  command "echo \"mysql-server-5.6 mysql-server/mysql_password password #{node["mysql"]["root_password"]}\" | debconf-set-selections"
   user "root"
 end
 execute "mysql-default-password-again" do
-  command "echo \"mysql-server-5.7 mysql-server/mysql_password_again password #{node["mysql"]["root_password"]}\" | debconf-set-selections"
+  command "echo \"mysql-server-5.6 mysql-server/mysql_password_again password #{node["mysql"]["root_password"]}\" | debconf-set-selections"
   user "root"
 end
 
@@ -18,7 +18,7 @@ end
 
 # Install mysql server
 execute "mysql-install" do
-  command "(export DEBIAN_FRONTEND=\"noninteractive\"; sudo -E apt-get install -y -q mysql-server-5.6 mysql-client-5.6 mysql-server-core-5.6)"
+  command "(export DEBIAN_FRONTEND=\"noninteractive\"; sudo -E apt-get install -y -q mysql-client-core-5.6 mysql-server-5.6 mysql-client-5.6)"
   user "root"
 end
 

--- a/configure/attributes/default.rb
+++ b/configure/attributes/default.rb
@@ -1,7 +1,7 @@
 cookbook_name = "configure"
 
 default[cookbook_name]["plugin_path"] = "/etc/chef/ohai_plugins"
-default[cookbook_name]["packages"] = ["git", "make", "curl", "unzip", "uuid", "mysql-client-5.7", "redis-tools", "libpcre3-dev", "tzdata", "default-jre"]
+default[cookbook_name]["packages"] = ["git", "make", "curl", "unzip", "uuid", "redis-tools", "libpcre3-dev", "tzdata", "default-jre"]
 
 default["timezone_iii"]["timezone"] = node["tz"]
 

--- a/configure/files/my.cnf
+++ b/configure/files/my.cnf
@@ -95,6 +95,9 @@ max_binlog_size   = 100M
 #
 # InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
 # Read the manual for more InnoDB related options. There are many!
+innodb_large_prefix=ON #Added to address DEV-488
+innodb_file_format=Barracuda #Added to address DEV-488
+innodb_file_per_table=true #Added to address DEV-488
 #
 # * Security Features
 #

--- a/configure/recipes/mysql.rb
+++ b/configure/recipes/mysql.rb
@@ -11,10 +11,16 @@ unless node.attribute?(:ec2)
     mode "0644"
   end
 
-  query = "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY \'#{node["mysql"]["root_password"]}\'; FLUSH PRIVILEGES;"
+  query = "SET PASSWORD FOR 'root'@'localhost' = PASSWORD(\'#{node["mysql"]["root_password"]}\');"
   execute "set_root-password" do
     command "echo \"#{query}\" | mysql -uroot"
     only_if "echo 'show databases' | mysql -uroot mysql;"
+  end
+
+  # Set Global innodb settings via cli to address DEV-488
+  query = "set global innodb_large_prefix=on; set global innodb_file_format=Barracuda;"
+  execute "set_innodb" do
+    command "echo \"#{query}\" | mysql -uroot -p#{node["mysql"]["root_password"]}"
   end
 
   # Create jbx user

--- a/configure/recipes/php.rb
+++ b/configure/recipes/php.rb
@@ -48,6 +48,6 @@ template "/etc/php/#{node["php"]["version"]}/fpm/pool.d/www.conf" do
   notifies :reload, "service[php#{node["php"]["version"]}-fpm.service]", :delayed
 end
 
-execute "composer self-update" do
+execute "composer self-update --1" do ##Pin to version 1 until we are ready to upgrade
   user "root"
 end


### PR DESCRIPTION
This helps restore some working order to Ubuntu16 + Mysql 5.6 and our php dependencies.

- [ ] Changes Out Mysql from 5.7 to 5.6 explicitly
- [ ] Version locks Composer to the latest stable 1.x major release
- [ ] Updates permissions call based on syntax differences
- [ ] Adds innodb changes to the configs 