### PR TITLE
AWS AMI

### DIFF
--- a/base/attributes/default.rb
+++ b/base/attributes/default.rb
@@ -11,6 +11,8 @@ default[cookbook_name]["net"]["ipv4.tcp_tw_reuse"] = "1"
 default[cookbook_name]["net"]["ipv4.tcp_slow_start_after_idle"] = "0"
 
 default["apt"]["compile_time_update"] = true
+override["configure"]["update"] = true
+override["configure"]["upgrade"] = true
 
 default["dnsmasq"]["dns"] = {
   "all-servers" => nil,
@@ -80,7 +82,7 @@ default["openresty"]["luarocks"]["checksum"] = "66c1848a25924917ddc1901e865add8f
 
 default["openresty"]["luarocks"]["default_rocks"] = {
   "lua-resty-auto-ssl" => "0.13.1",
-  "jumbleberry-dogstatsd" => "1.0.1-1"
+  "jumbleberry-dogstatsd" => "1.0.1-1",
 }
 
 default["php"]["version"] = php_version = "7.3"

--- a/base/recipes/apt.rb
+++ b/base/recipes/apt.rb
@@ -1,0 +1,11 @@
+if node[:configure][:update]
+  execute "apt-get update" do
+    action :run
+  end
+end
+
+if node[:configure][:upgrade]
+  execute "apt-get upgrade -y" do
+    action :run
+  end
+end

--- a/base/recipes/default.rb
+++ b/base/recipes/default.rb
@@ -1,10 +1,7 @@
 include_recipe "apt"
 
-if node["environment"] != "prod"
-  include_recipe cookbook_name + "::trust"
-end
-
 unless node.attribute?(:ec2)
+  include_recipe cookbook_name + "::trust"
   include_recipe cookbook_name + "::berks"
 end
 
@@ -22,10 +19,7 @@ include_recipe cookbook_name + "::phalcon"
 include_recipe cookbook_name + "::gearman"
 include_recipe cookbook_name + "::nodejs"
 include_recipe cookbook_name + "::mysql"
-
-if node["environment"] == "dev"
-  include_recipe cookbook_name + "::timescale"
-end
+include_recipe cookbook_name + "::timescale"
 
 include_recipe "security"
 

--- a/base/recipes/default.rb
+++ b/base/recipes/default.rb
@@ -20,6 +20,7 @@ include_recipe cookbook_name + "::gearman"
 include_recipe cookbook_name + "::nodejs"
 include_recipe cookbook_name + "::mysql"
 include_recipe cookbook_name + "::timescale"
+include_recipe cookbook_name + "::apt"
 
 include_recipe "security"
 

--- a/base/recipes/phalcon.rb
+++ b/base/recipes/phalcon.rb
@@ -1,9 +1,11 @@
 execute "curl -s #{node["phalcon"]["install_script"]} | sudo bash"
 
-package "php#{node["php"]["version"]}-phalcon" do
-  action :install
+apt_package "php#{node["php"]["version"]}-phalcon" do
   version node["phalcon"]["version"]
+  action %i{install lock}
 end
+
+execute "apt-mark hold php#{node["php"]["version"]}-phalcon"
 
 unless node.attribute?(:ec2)
   git "phalcon-devtools" do

--- a/configure/attributes/default.rb
+++ b/configure/attributes/default.rb
@@ -2,6 +2,8 @@ cookbook_name = "configure"
 
 default[cookbook_name]["plugin_path"] = "/etc/chef/ohai_plugins"
 default[cookbook_name]["packages"] = ["git", "make", "curl", "unzip", "uuid", "redis-tools", "libpcre3-dev", "tzdata", "default-jre"]
+default[cookbook_name]["update"] = false
+default[cookbook_name]["upgrade"] = false
 
 default["timezone_iii"]["timezone"] = node["tz"]
 

--- a/configure/recipes/mysql.rb
+++ b/configure/recipes/mysql.rb
@@ -65,7 +65,6 @@ if node["environment"] == "dev" && (node["configure"]["services"]["mysql"] && (n
   execute "manage_mysql_settings" do
     command "echo \"#{query}\" | mysql -uroot -p#{node["mysql"]["root_password"]}"
     only_if "echo 'show databases' | mysql -uroot -p#{node["mysql"]["root_password"]} mysql;"
-    action :nothing
   end
 
   edit_resource(:service, "mysql.service") do

--- a/configure/recipes/timescale.rb
+++ b/configure/recipes/timescale.rb
@@ -2,15 +2,15 @@ if node["environment"] == "dev"
   # Copy config files
   cookbook_file "/etc/postgresql/12/main/pg_hba.conf" do
     source "pg_hba.conf"
-    owner "root"
-    group "root"
+    owner "postgres"
+    group "postgres"
     mode "0644"
     notifies :reload, "service[postgresql.service]", :immediate
   end
   cookbook_file "/etc/postgresql/12/main/postgresql.conf" do
     source "postgresql.conf"
-    owner "root"
-    group "root"
+    owner "postgres"
+    group "postgres"
     mode "0644"
     notifies :restart, "service[postgresql.service]", :immediate
     notifies :run, "execute[convert-pgdb-to-timescaledb]", :delayed

--- a/jbx/templates/default/default.conf.erb
+++ b/jbx/templates/default/default.conf.erb
@@ -10,7 +10,11 @@ server {
     }
 
     location = /nginx {
-        allow                       127.0.0.1;
+        allow                       10.0.0.0/8;
+        allow                       127.0.0.1/32;
+        allow                       172.16.0.0/12;
+        allow                       192.168.0.0/16;
+        allow                       fd00::/8;
         deny                        all;
         
         stub_status                 on;


### PR DESCRIPTION
Run apt `upgrade/update` on setup, to account for OpsWorks no longer doing so on our behalf.

Otherwise minor bug fixes and recipe re-arrangement to ensure AWS base box contains necessary dependencies for all environments (dev, staging, prod), without sacrificing system security.