### PR TITLE
Xdebug 3

### DIFF
--- a/configure/attributes/default.rb
+++ b/configure/attributes/default.rb
@@ -33,12 +33,13 @@ default["php"]["fpm"]["mods_dirs"] = ["/etc/php/#{php_version}/mods-available"]
 default["php"]["fpm"]["conf_dirs"] = ["/etc/php/#{php_version}/cli", "/etc/php/#{php_version}/fpm"]
 
 default["php"]["xdebug"] = {
-  "remote_enable" => true,
-  "remote_autostart" => true,
-  "remote_host" => "10.0.2.2",
-  "remote_port" => 9000,
+  "mode" => "debug",
+  "client_host" => "10.0.2.2",
+  "client_port" => 9003,
   "remote_log" => "/var/log/xdebug.log",
   "max_nesting_level" => 1000,
+  "idekey" => "PHPSTORM",
+  "start_with_request" => "yes",
 }
 
 default["gearman"]["retries"] = 1


### PR DESCRIPTION
We updated XDebug version from 2 to 3. There is a few important different between this 2 versions. For example ports changed and config options changed names. In this PR I fixed all problems what we had after update. 
References: https://xdebug.org/docs/upgrade_guide

