### PR TITLE
Add pgloader for seeding timescale

### DIFF
--- a/base/recipes/timescale.rb
+++ b/base/recipes/timescale.rb
@@ -23,3 +23,7 @@ service "postgresql.service" do
   service_name "postgresql"
   action %i{stop disable}
 end
+
+package "pgloader" do
+  action :install
+end


### PR DESCRIPTION
adding the `pgloader` package, it will be used to copy mysql table into postgres when we seed the local timescale db.