### PR TITLE
Add DD_Version to php for deployment tracking

### DIFF
--- a/configure/recipes/default.rb
+++ b/configure/recipes/default.rb
@@ -1,3 +1,14 @@
+node.default[:commit_hash] = "null"
+
+ruby_block "jbx_version" do
+  block do
+    %s(su #{node[:user]; git config --global --add safe.directory #{node["jbx"]["path"]})
+    commit_hash = %x(cd #{node["jbx"]["path"]}; git rev-parse HEAD)
+    node.default[:commit_hash] = "#{commit_hash.strip}"
+  end
+  action :run
+end
+
 include_recipe cookbook_name + "::dnsmasq"
 include_recipe cookbook_name + "::network"
 

--- a/configure/templates/default/www.conf.erb
+++ b/configure/templates/default/www.conf.erb
@@ -380,6 +380,7 @@ env[DD_PROFILING_ENABLED] = <%= (node[:datadog][:enable_profiling] || 0) && "tru
 env[DD_TRACE_ENABLED] = <%= (node[:datadog][:enable_trace_agent] || 0) && "true" || "false" %>
 env[DD_AGENT_HOST] = $HOSTNAME
 env[DD_SERVICE] = <%= node.read("datadog", "tags", "service") || "dev" %>
+env[DD_VERSION] = <%= (node["commit_hash"]) || "env[DD_VERSION] = lazy {node[commit_hash]}" %>
 
 ; Additional php.ini defines, specific to this pool of workers. These settings
 ; overwrite the values previously defined in the php.ini. The directives are the


### PR DESCRIPTION
This seems to consistently enable us to include the hash of the running JBX code to send to Datadog for better error tracking and APM.
<img width="544" alt="Screen Shot 2022-06-11 at 12 57 23 AM" src="https://user-images.githubusercontent.com/1209293/173173392-3a7223a7-b240-4ad7-aab3-4873fc9acb44.png">
