### PR TITLE
chore: Update vault addresses to squaredance.io

### DIFF
--- a/base/attributes/default.rb
+++ b/base/attributes/default.rb
@@ -57,7 +57,7 @@ default["hashicorp-vault"]["gems"] = {
 }
 default["hashicorp-vault"]["version"] = "1.10.0"
 default["hashicorp-vault"]["config"]["path"] = "/etc/vault/vault.json"
-default["hashicorp-vault"]["config"]["address"] = "https://vault.jumbleberry.com"
+default["hashicorp-vault"]["config"]["address"] = "https://vault.squaredance.io"
 
 default["consul"]["config"]["bind_addr"] = node["ipaddress"]
 default["consul"]["config"]["advertise_addr"] = node["ipaddress"]

--- a/configure/recipes/vault.rb
+++ b/configure/recipes/vault.rb
@@ -21,7 +21,7 @@ ruby_block "get_vault_token" do
     if node.attribute?(:ec2)
       if !defined?(node.run_state["VAULT_TOKEN"]) || node.run_state["VAULT_TOKEN"].nil?
         begin
-          login_command = "VAULT_ADDR=\"#{node["hashicorp-vault"]["config"]["address"]}\" vault login -token-only -method=aws header_value=vault.jumbleberry.com role=#{node["environment"]}-#{node["role"]}"
+          login_command = "VAULT_ADDR=\"#{node["hashicorp-vault"]["config"]["address"]}\" vault login -token-only -method=aws header_value=vault.squaredance.io role=#{node["environment"]}-#{node["role"]}"
           node.run_state["VAULT_TOKEN"] = shell_out(login_command).stdout
           Vault.token = node.run_state["VAULT_TOKEN"]
           Vault.auth_token.lookup_self


### PR DESCRIPTION
Moves over from `vault.jumbleberry.com` to `vault.squaredance.io`.