### PR TITLE
Fix version variable to correctly track repository

### DIFF
--- a/jbx/templates/default/api.erb
+++ b/jbx/templates/default/api.erb
@@ -77,7 +77,7 @@ server {
         fastcgi_param PATH_INFO         $fastcgi_path_info;
         fastcgi_param PATH_TRANSLATED   $document_root$fastcgi_path_info;
         fastcgi_param SCRIPT_FILENAME   $document_root$fastcgi_script_name;
-        fastcgi_param DD_VERSION	<%= node.run_state[:jbx_version] || node[:environment] %>;
+        fastcgi_param DD_VERSION        "<%= @version %>";
         include                         fastcgi_params;
     }
 }


### PR DESCRIPTION
While `jbx_version` is deferred to run on the `converge` phase, it still runs first in logical order compared to checking out the `jbx` repository. This means that `jbx_version` still lagged behind the true version that would eventually be checked out.

