### PR TITLE
Tune settings for PHP 8

### DIFF
--- a/base/templates/default/phalcon.ini.erb
+++ b/base/templates/default/phalcon.ini.erb
@@ -1,2 +1,3 @@
 [Phalcon]
 extension=phalcon.so
+phalcon.orm.ignore_unknown_columns = On

--- a/configure/recipes/datadog.rb
+++ b/configure/recipes/datadog.rb
@@ -2,22 +2,33 @@ node.default["datadog"]["tags"]["environment"] = node["environment"]
 node.default["datadog"]["tags"]["service"] = (node.read("opsworks", "instance", "role") || ["dev"]).join("|")
 
 datadog_enabled = node["configure"]["services"]["datadog"] && (node["configure"]["services"]["datadog"].include? "start")
-datadog_php_ini = "/etc/php/#{node["php"]["version"]}/fpm/conf.d/98-ddtrace.ini"
 
-replace_or_add "datadog tracing" do
-  path datadog_php_ini
-  pattern ".*extension.*?=.*?ddtrace.so.*"
-  line (datadog_enabled && node["datadog"]["enable_trace_agent"] ? "" : ";") + "extension = ddtrace.so"
-  notifies :restart, "service[php#{node["php"]["version"]}-fpm.service]", :delayed
-  only_if { ::File.exist?(datadog_php_ini) }
-end
+node["php"]["fpm"]["conf_dirs"].each do |path|
+  datadog_php_ini = "#{path}/conf.d/98-ddtrace.ini"
 
-replace_or_add "datadog profiling" do
-  path datadog_php_ini
-  pattern ".*zend_extension.*?=.*?datadog-profiling.so.*"
-  line (datadog_enabled && node["datadog"]["enable_profiling"] ? "" : ";") + "zend_extension = datadog-profiling.so"
-  notifies :restart, "service[php#{node["php"]["version"]}-fpm.service]", :delayed
-  only_if { ::File.exist?(datadog_php_ini) }
+  replace_or_add "datadog tracing" do
+    path datadog_php_ini
+    pattern ".*extension.*?=.*?ddtrace.so.*"
+    line (datadog_enabled && node["datadog"]["enable_trace_agent"] ? "" : ";") + "extension = ddtrace.so"
+    notifies :restart, "service[php#{node["php"]["version"]}-fpm.service]", :delayed if path.include? "fpm"
+    only_if { ::File.exist?(datadog_php_ini) }
+  end
+
+  replace_or_add "datadog profiling" do
+    path datadog_php_ini
+    pattern ".*extension.*?=.*?datadog-profiling.so.*"
+    line (datadog_enabled && node["datadog"]["enable_profiling"] ? "" : ";") + "extension = datadog-profiling.so"
+    notifies :restart, "service[php#{node["php"]["version"]}-fpm.service]", :delayed if path.include? "fpm"
+    only_if { ::File.exist?(datadog_php_ini) }
+  end
+
+  replace_or_add "datadog request_init_hook" do
+    path datadog_php_ini
+    pattern ".*request_init_hook.*"
+    line ";datadog.trace.request_init_hook = ''"
+    notifies :restart, "service[php#{node["php"]["version"]}-fpm.service]", :delayed if path.include? "fpm"
+    only_if { ::File.exist?(datadog_php_ini) }
+  end
 end
 
 if datadog_enabled

--- a/configure/recipes/php.rb
+++ b/configure/recipes/php.rb
@@ -1,10 +1,21 @@
+template "/etc/php/#{node["php"]["version"]}/mods-available/opcache.ini" do
+  manage_symlink_source true
+  source "opcache.ini.erb"
+  owner "root"
+  group "root"
+  mode 0644
+  notifies :reload, "service[php#{node["php"]["version"]}-fpm.service]", :delayed
+end
+
 # Fpm configurations
 node["php"]["fpm"]["conf_dirs"].each do |path|
   template path + "/php.ini" do
     source "php.ini.erb"
     variables({
+      "sapi" => ::File.basename(path),
       "display_errors" => node["php"]["fpm"]["display_errors"],
       "include_path" => node["php"]["fpm"]["include_path"],
+      "preload" => "/var/www/jbx/application/library/Bootstrap.php",
     })
     if path.include? "fpm"
       notifies :reload, "service[php#{node["php"]["version"]}-fpm.service]", :delayed
@@ -34,7 +45,7 @@ node["php"]["fpm"]["conf_dirs"].each do |path|
   end
 end
 
-include_recipe 'logrotate'
+include_recipe "logrotate"
 
 logrotate_app "php" do
   path node["php"]["logfile"]

--- a/configure/templates/default/opcache.ini.erb
+++ b/configure/templates/default/opcache.ini.erb
@@ -1,0 +1,5 @@
+; configuration for php opcache module
+; priority=10
+zend_extension=opcache.so
+opcache.jit=1203
+opcache.jit_buffer_size=256M

--- a/configure/templates/default/php.ini.erb
+++ b/configure/templates/default/php.ini.erb
@@ -457,7 +457,7 @@ memory_limit = 1024M
 ; Development Value: E_ALL
 ; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
 ; http://php.net/error-reporting
-error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT
+error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 
 ; This directive controls whether or not and where PHP will output errors,
 ; notices and warnings too. Error output is very useful during development, but
@@ -977,7 +977,8 @@ cli_server.color = On
 ;iconv.output_encoding =
 
 [intl]
-;intl.default_locale =
+intl.default_locale = en_US.UTF-8
+
 ; This directive allows you to produce PHP errors when some error
 ; happens within intl functions. The value is the level of the error produced.
 ; Default is 0, which does not produce any errors.
@@ -1765,10 +1766,10 @@ ldap.max_links = -1
 
 [opcache]
 ; Determines if Zend OPCache is enabled
-opcache.enable=<% if node['environment'] != 'dev' -%>1<% else -%>0<% end -%>
+opcache.enable=<% if node['environment'] != 'dev' || @sapi.include?("cli") -%>1<% else -%>0<% end -%>
 
 ; Determines if Zend OPCache is enabled for the CLI version of PHP
-;opcache.enable_cli=0
+opcache.enable_cli=1
 
 ; The OPcache shared memory storage size.
 opcache.memory_consumption=256
@@ -1814,7 +1815,7 @@ opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes
-;opcache.optimization_level=0xffffffff
+opcache.optimization_level=0x7FFEBFFF
 
 ;opcache.inherited_hack=1
 ;opcache.dups_fix=0
@@ -1829,7 +1830,7 @@ opcache.enable_file_override=1
 
 ; Allows exclusion of large files from being cached. By default all files
 ; are cached.
-opcache.max_file_size=5120000
+opcache.max_file_size=16777216
 
 ; Check the cache checksum each N requests.
 ; The default value of "0" means that the checks are disabled.
@@ -1883,13 +1884,22 @@ opcache.consistency_checks=0
 
 ; Enables or disables copying of PHP code (text segment) into HUGE PAGES.
 ; This should improve performance, but requires appropriate OS configuration.
-;opcache.huge_code_pages=1
+opcache.huge_code_pages=1
 
 ; Validate cached file permissions.
 opcache.validate_permission=0
 
 ; Prevent name collisions in chroot'ed environment.
 opcache.validate_root=0
+
+; Opcache Preload File
+opcache.preload=<%= @sapi.include?("fpm") && ::File.exist?(@preload) ? @preload : '' %>
+opcache.preload_user=www-data
+
+[apcu]
+apc.enabled=1
+apc.enable_cli=1
+apc.serializer=igbinary
 
 [curl]
 ; A default value for the CURLOPT_CAINFO option. This is required to be an
@@ -1917,3 +1927,25 @@ opcache.validate_root=0
 ; Local Variables:
 ; tab-width: 4
 ; End:
+
+[datadog]
+datadog.trace.amqp_enabled          = 0
+datadog.trace.cakephp_enabled       = 0
+datadog.trace.codeigniter_enabled   = 0
+datadog.trace.eloquent_enabled      = 0
+datadog.trace.laminas_enabled       = 0
+datadog.trace.laravel_enabled       = 0
+datadog.trace.laravelqueue_enabled  = 0
+datadog.trace.lumen_enabled         = 0
+datadog.trace.mongo_enabled         = 0
+datadog.trace.mongodb_enabled       = 0
+datadog.trace.mysqli_enabled        = 0
+datadog.trace.nette_enabled         = 0
+datadog.trace.phpredis_enabled      = 0
+datadog.trace.roadrunner_enabled    = 0
+datadog.trace.sqlsrv_enabled        = 0
+datadog.trace.slim_enabled          = 0
+datadog.trace.symfony_enabled       = 0
+datadog.trace.wordpress_enabled     = 0
+datadog.trace.yii_enabled           = 0
+datadog.trace.zendframework_enabled = 0


### PR DESCRIPTION
Tuning for PHP/DDTrace for PHP 8

Our `php.ini` was originally from 5.4 so is missing some knobs that we should be using on 8. 
The DDTrace changes are in preparation for the APM telemetry I have coming. The trace library now exposes functions in PHP user-land so I don't need to patch the c code anymore, I can load it as a PHP library