### PR TITLE
feat: Allow underscore on headers in nginx

### DIFF
--- a/configure/templates/default/nginx.conf.erb
+++ b/configure/templates/default/nginx.conf.erb
@@ -47,6 +47,9 @@ http {
   keepalive_timeout       <%= node['openresty']['keepalive_timeout'] %>;
   <% end %>
 
+  # Allow underscore in headers
+  underscores_in_headers on;
+
   server_names_hash_bucket_size <%= node['openresty']['server_names_hash_bucket_size'] %>;
   types_hash_max_size     <%= node['openresty']['types_hash_max_size'] %>;
   types_hash_bucket_size  <%= node['openresty']['types_hash_bucket_size'] %>;

--- a/openresty/templates/default/nginx.conf.erb
+++ b/openresty/templates/default/nginx.conf.erb
@@ -55,6 +55,9 @@ http {
   keepalive_timeout  <%= node['openresty']['keepalive_timeout'] %>;
   <% end %>
 
+  # Allow undersocer in headers
+  underscores_in_headers on;
+
   gzip  <%= node['openresty']['gzip'] %>;
   <% if node['openresty']['gzip'] == "on" %>
   gzip_http_version <%= node['openresty']['gzip_http_version'] %>;

--- a/openresty/templates/default/nginx.conf.erb
+++ b/openresty/templates/default/nginx.conf.erb
@@ -55,9 +55,6 @@ http {
   keepalive_timeout  <%= node['openresty']['keepalive_timeout'] %>;
   <% end %>
 
-  # Allow undersocer in headers
-  underscores_in_headers on;
-
   gzip  <%= node['openresty']['gzip'] %>;
   <% if node['openresty']['gzip'] == "on" %>
   gzip_http_version <%= node['openresty']['gzip_http_version'] %>;


### PR DESCRIPTION
add support for underscores in headers, it's disabled by default but it's safe to enable:

http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers