### PR TITLE
Chore: Standardize Datadog Environment Variables

### DIFF
--- a/configure/recipes/datadog.rb
+++ b/configure/recipes/datadog.rb
@@ -1,4 +1,4 @@
-node.default["datadog"]["tags"]["environment"] = node["environment"]
+node.default["datadog"]["tags"]["environment"] = (node["environment"].include? "prod" ? "production": node["environment"])
 node.default["datadog"]["tags"]["service"] = (node.read("opsworks", "instance", "role") || ["dev"]).join("|")
 
 datadog_enabled = node["configure"]["services"]["datadog"] && (node["configure"]["services"]["datadog"].include? "start")


### PR DESCRIPTION
Mesh and JBX have always been 'prod' in Datadog where everything else is 'production'.
This has created some consistently annoying observability and visibility blockers.

This change allows us to leave our existing environment variables intact through opsworks declarations and cookbooks while improving our use inside of Datadog.